### PR TITLE
Add model tracing and correctness checks for Metropolis-Hastings

### DIFF
--- a/piper/functional/__init__.py
+++ b/piper/functional/__init__.py
@@ -6,7 +6,8 @@ from piper.functional.kl_divergence import compute_kl_div
 from piper.functional.log_prob_module import log_prob
 from piper.functional.metropolis_hastings_module import metropolis_hastings
 from piper.functional.sampler import sample
+from piper.functional.trace_module import trace
 
 __all__ = [
-    "compute_kl_div", "sample", "condition", "log_prob", "metropolis_hastings"
+    "compute_kl_div", "sample", "condition", "log_prob", "metropolis_hastings", "trace"
 ]

--- a/piper/functional/log_prob_module.py
+++ b/piper/functional/log_prob_module.py
@@ -1,37 +1,18 @@
 # Copyright (c) 2020 Branislav Holländer. All rights reserved.
 # See the file LICENSE for copying permission.
 
-from typing import Callable
-
-import jax.numpy as jnp
-
-from piper.distributions import distribution as dist
-from piper.functional.modifier import Modifier
+from piper import tree
 
 
-class log_prob(Modifier):
-    def __init__(self, fn: Callable):
-        """Modifier to calculate log probability.
+def log_prob(tr: tree.Tree):
+    """Calculates log probability given the trace tree.
 
-        Calculates the log probability of a stochastic function
-        according to the log probabilities of individual
-        distributions and sampled values.
+    If you want to calculate the log probability of specific
+    values under the model, condition on them appropriately.
+    """
+    logp = 0
 
-        If you want to calculate the log probability of specific
-        values under the model, condition on them appropriately.
-        """
-        super().__init__(fn)
-        self.log_prob = 0
+    for node in tr.nodes.values():
+        logp += node.distribution.log_prob(node.value)
 
-    def __enter__(self):
-        super().__enter__()
-        return self
-
-    def post_process(self, sample: jnp.ndarray, node_name: str,
-                     d: dist.Distribution):
-        self.log_prob += d.log_prob(sample)
-
-    def get(self):
-        """Return calculated log probability.
-        """
-        return self.log_prob
+    return logp

--- a/piper/functional/modifier.py
+++ b/piper/functional/modifier.py
@@ -1,12 +1,9 @@
 # Copyright (c) 2020 Branislav Holländer. All rights reserved.
 # See the file LICENSE for copying permission.
 
-from typing import Callable
-
-import jax.numpy as jnp
+from typing import Callable, Dict
 
 from piper import core
-from piper.distributions import distribution as dist
 
 
 class Modifier:
@@ -22,12 +19,11 @@ class Modifier:
         assert core._MODIFIER_STACK[-1] == self
         core._MODIFIER_STACK.pop()
 
-    def process(self, node_name: str, d: dist.Distribution):
-        pass
+    def process(self, message: Dict) -> Dict:
+        return message
 
-    def post_process(self, sample: jnp.ndarray, node_name: str,
-                     d: dist.Distribution):
-        pass
+    def post_process(self, message: Dict) -> Dict:
+        return message
 
     def __call__(self, *args, **kwargs):
         with self:

--- a/piper/functional/sampler.py
+++ b/piper/functional/sampler.py
@@ -8,16 +8,20 @@ from piper.distributions import distribution as dist
 
 
 def sample(sample_name: str, d: dist.Distribution, key: jnp.ndarray):
-    sample = None
+    message = {
+        'name': sample_name,
+        'sample': None,
+        'distribution': d,
+        'is_conditioned': False
+    }
+
     for mod in core._MODIFIER_STACK[::-1]:
-        new_sample = mod.process(sample_name, d)
-        sample = sample if new_sample is None else new_sample
+        message = mod.process(message)
 
-    if sample is None:
-        sample = d.sample(key)
+    if message['sample'] is None:
+        message['sample'] = d.sample(key)
 
     for mod in core._MODIFIER_STACK[::-1]:
-        new_sample = mod.post_process(sample, sample_name, d)
-        sample = sample if new_sample is None else new_sample
+        message = mod.post_process(message)
 
-    return sample
+    return message['sample']

--- a/piper/functional/trace_module.py
+++ b/piper/functional/trace_module.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 Branislav Holländer. All rights reserved.
+# See the file LICENSE for copying permission.
+
+from typing import Callable, Dict
+
+from piper.functional.modifier import Modifier
+from piper import tree
+
+
+class trace(Modifier):
+    def __init__(self, fn: Callable):
+        """Modifier to calculate log probability.
+
+        Calculates the log probability of a stochastic function
+        according to the log probabilities of individual
+        distributions and sampled values.
+
+        If you want to calculate the log probability of specific
+        values under the model, condition on them appropriately.
+        """
+        super().__init__(fn)
+        self.tree = tree.Tree()
+
+    def __enter__(self):
+        super().__enter__()
+        return self
+
+    def post_process(self, message: Dict):
+        self.tree.add_node(
+            message['name'],
+            tree.Node(message['distribution'],
+                      message['sample'],
+                      message['is_conditioned']))
+
+        return message
+
+    def get_tree(self):
+        """Return traced tree.
+        """
+        return self.tree

--- a/piper/tree.py
+++ b/piper/tree.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Branislav Holländer. All rights reserved.
+# See the file LICENSE for copying permission.
+
+import jax.numpy as jnp
+
+from piper.distributions.distribution import Distribution
+
+
+class Node:
+    def __init__(self,
+                 dist: Distribution,
+                 val: jnp.ndarray,
+                 is_conditioned: bool):
+        self.distribution = dist
+        self.value = val
+        self.is_conditioned = is_conditioned
+
+
+class Tree:
+    def __init__(self):
+        self.nodes = {}
+
+    def add_node(self, name: str, node: Node):
+        if name in self.nodes:
+            raise ValueError("Node already in the tree")
+
+        self.nodes[name] = node

--- a/tests/functional/test_log_prob.py
+++ b/tests/functional/test_log_prob.py
@@ -15,19 +15,21 @@ def test_log_prob_normal():
         return n1
 
     # Unconditioned
-    log_prob_calculator = func.log_prob(model)
+    tracer = func.trace(model)
     key = jax.random.PRNGKey(123)
-    log_prob_calculator(key)
-    log_prob = log_prob_calculator.get()
+    tracer(key)
+    tree = tracer.get_tree()
+    log_prob = func.log_prob(tree)
 
     tu.check_close(log_prob, -1.2025023)
 
     # Conditioned
     conditioned_model = func.condition(model, {'n1': jnp.array(0.)})
-    log_prob_calculator = func.log_prob(conditioned_model)
+    tracer = func.trace(conditioned_model)
     key = jax.random.PRNGKey(123)
-    log_prob_calculator(key)
-    log_prob = log_prob_calculator.get()
+    tracer(key)
+    tree = tracer.get_tree()
+    log_prob = func.log_prob(tree)
 
     tu.check_close(log_prob, -0.9189385)
 
@@ -45,9 +47,10 @@ def test_log_prob_normal_normal():
         'n1': jnp.array(0.),
         'n2': jnp.array(1.)
     })
-    log_prob_calculator = func.log_prob(conditioned_model)
+    tracer = func.trace(conditioned_model)
     key = jax.random.PRNGKey(123)
-    log_prob_calculator(key)
-    log_prob = log_prob_calculator.get()
+    tracer(key)
+    tree = tracer.get_tree()
+    log_prob = func.log_prob(tree)
 
     tu.check_close(log_prob, -2.337877)

--- a/tests/functional/test_metropolis_hastings.py
+++ b/tests/functional/test_metropolis_hastings.py
@@ -17,30 +17,20 @@ def test_metropolis_hastings_wrong_proposal_or_initial_samples():
         n2 = func.sample('n2', dist.normal(n1, jnp.array(1.)), key)
         return n2
 
-    def proposal1(key, **current):
-        n4 = func.sample('n4', dist.normal(current['n1'], jnp.array(1.)), key)
+    def proposal(key, **current):
+        n4 = func.sample('n4', dist.normal(current['n4'], jnp.array(1.)), key)
         return {'n4': n4}
 
     conditioned_model = func.condition(model, {'n2': jnp.array(0.5)})
-    initial_samples = {'n1': jnp.array(0.)}
+    initial_samples = {'n4': jnp.array(0.)}
 
-    with pytest.raises(RuntimeError):  # wrong proposal function
-        func.metropolis_hastings(conditioned_model,
-                                 proposal1,
-                                 initial_samples,
-                                 num_chains=1)
-
-    def proposal2(key, **current):
-        n1 = func.sample('n1', dist.normal(current['n1'], jnp.array(1.)), key)
-        return {'n1': n1}
-
-    initial_samples = {'n3': jnp.array(0.)}
-
-    with pytest.raises(RuntimeError):
-        func.metropolis_hastings(conditioned_model,
-                                 proposal2,
-                                 initial_samples,
-                                 num_chains=1)
+    with pytest.raises(RuntimeError):  # wrong proposal and initial samples
+        key = jax.random.PRNGKey(123)
+        mcmc_model = func.metropolis_hastings(conditioned_model,
+                                              proposal,
+                                              initial_samples,
+                                              num_chains=1)
+        mcmc_model(key)
 
 
 def test_metropolis_hastings_normal_one_chain():
@@ -71,8 +61,7 @@ def test_metropolis_hastings_normal_one_chain():
 def test_metropolis_hastings_normal_normal_one_chain():
     def model(key):
         keys = jax.random.split(key, 2)
-        n1 = func.sample('n1',
-                         dist.normal(jnp.array(0.), jnp.array(1.)),
+        n1 = func.sample('n1', dist.normal(jnp.array(0.), jnp.array(1.)),
                          keys[0])
         n2 = func.sample('n2', dist.normal(n1, jnp.array(1.)), keys[1])
         return n2
@@ -102,8 +91,7 @@ def test_metropolis_hastings_normal_normal_one_chain():
 def test_metropolis_hastings_normal_normal_10_chains():
     def model(key):
         keys = jax.random.split(key, 2)
-        n1 = func.sample('n1',
-                         dist.normal(jnp.array(0.), jnp.array(1.)),
+        n1 = func.sample('n1', dist.normal(jnp.array(0.), jnp.array(1.)),
                          keys[0])
         n2 = func.sample('n2', dist.normal(n1, jnp.array(1.)), keys[1])
         return n2
@@ -142,9 +130,8 @@ def test_metropolis_hastings_normal_normal_multidim_10_chains():
     conditioned_model = func.condition(model, {'n2': jnp.full((2, 2), 0.5)})
 
     def proposal(key, **current):
-        n1 = func.sample('n1',
-                         dist.normal(current['n1'], jnp.full((2, 2), 5.)),
-                         key)
+        n1 = func.sample('n1', dist.normal(current['n1'], jnp.full((2, 2),
+                                                                   5.)), key)
         return {'n1': n1}
 
     initial_samples = {'n1': jnp.zeros((2, 2))}
@@ -168,8 +155,7 @@ def test_metropolis_hastings_normal_normal_multidim_10_chains():
 def test_metropolis_hastings_beta_bernoulli_10chains():
     def model(key):
         keys = jax.random.split(key, 2)
-        n1 = func.sample('n1',
-                         dist.beta(jnp.array(0.5), jnp.array(0.5)),
+        n1 = func.sample('n1', dist.beta(jnp.array(0.5), jnp.array(0.5)),
                          keys[0])
         n2 = func.sample('n2', dist.bernoulli(n1), keys[1])
         return n2

--- a/tests/functional/test_trace.py
+++ b/tests/functional/test_trace.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2020 Branislav Holländer. All rights reserved.
+# See the file LICENSE for copying permission.
+
+import jax
+import jax.numpy as jnp
+
+import piper.functional as func
+import piper.distributions as dist
+
+
+def test_trace_normal_normal():
+    def model(key):
+        keys = jax.random.split(key)
+        n1 = func.sample('n1', dist.normal(jnp.array(0.), jnp.array(1.)),
+                         keys[0])
+        n2 = func.sample('n2', dist.normal(n1, jnp.array(1.)), keys[1])
+        return n2
+
+    conditioned_model = func.condition(model, {
+        'n1': jnp.array(0.),
+        'n2': jnp.array(1.)
+    })
+    tracer = func.trace(conditioned_model)
+    key = jax.random.PRNGKey(123)
+    tracer(key)
+    tree = tracer.get_tree()
+
+    assert 'n1' in tree.nodes \
+        and tree.nodes['n1'].distribution.mu == 0. \
+        and tree.nodes['n1'].distribution.sigma == 1. \
+        and tree.nodes['n1'].value == 0.
+
+    assert 'n2' in tree.nodes \
+        and tree.nodes['n2'].distribution.mu == 0. \
+        and tree.nodes['n2'].distribution.sigma == 1. \
+        and tree.nodes['n2'].value == 1.


### PR DESCRIPTION
Instead of directly dealing with samples when sampling, we are now sending messages between the modifiers with more information, such as the name of the sample, the distribution as well as information on node distribution conditioning.

A new modifier, trace, was introduced which returns a Tree structure containing all sampled nodes and appropriate information about them.
We also calculate log probability from the Tree structure. log_prob isn't a Modifier anymore, instead it is a plain function.

In the Metropolis-Hastings algorithm, it is now possible to check if the provided initial samples and proposal distribution provide the correct samples for the model.

Fixes #3, fixes #4. 